### PR TITLE
more stable dependency update?

### DIFF
--- a/run_build_impl.sh
+++ b/run_build_impl.sh
@@ -77,8 +77,8 @@ do
     foldername_w_ext=${dependency##*/}
     foldername=${foldername_w_ext%.*}
     if [ -d $foldername ]; then
-      echo Package "$foldername" exists, running git pull and git submodule update --recursive on "$dependency"
-      cd "$foldername" && git pull --depth 1 && git submodule update --recursive && cd ..
+      echo Package "$foldername" exists, running git fetch --depth 1, git reset --hard origin/HEAD and git submodule update --recursive on "$dependency"
+      cd "$foldername" && git fetch --depth 1 && git reset --hard origin/HEAD && git submodule update --recursive && cd ..
     else
       echo Package "$foldername" does not exists, running git clone "$dependency" --recursive
       git clone "$dependency" --recursive --depth 1 --single-branch


### PR DESCRIPTION
There seems to be a problem (yielding conflicts on pull) with the `--depth 1` and some changes upstream (no idea what exactly is the problem). 
I found that happening a lot with the new tag 0.1.1 for catkin_simple. See for example (from http://129.132.38.183:8080/job/curves/32/console):

```
Package catkin_simple exists, running git pull and git submodule update --recursive on git@github.com:catkin/catkin_simple.git
From github.com:catkin/catkin_simple
 + d049aa8...a6c063f master     -> origin/master  (forced update)
 * [new tag]         0.1.1      -> 0.1.1
Auto-merging package.xml
CONFLICT (add/add): Merge conflict in package.xml
Automatic merge failed; fix conflicts and then commit the result.

```

This happened already to many packages. 

Shall I reset all the catkin_simple work trees on Jenkins? I have that for loop already ;).
