### PR TITLE
introduced CI_IGNORE to allow exclusion of a package from CI package auto discovery

### DIFF
--- a/ignored_package_CI_IGNORE/CMakeLists.txt
+++ b/ignored_package_CI_IGNORE/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(ignored_test_ci_ignore)
+
+find_package(catkin_simple REQUIRED)
+catkin_simple()
+
+non_existing_cmake_method_to_check_that_this_package_is_correctly_ignored()
+
+cs_install()
+cs_export()

--- a/ignored_package_CI_IGNORE/package.xml
+++ b/ignored_package_CI_IGNORE/package.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <name>ignored_test_ci_ignore</name>
+  <version>0.0.1</version>
+  <description>
+     excluded from package auto discovery because of the top level file CI_IGNORE
+  </description>
+  <maintainer email="simon.lynen@mavt.ethz.ch">Simon Lynen</maintainer>
+  <license>BSD</license>
+  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>catkin_simple</buildtool_depend>
+  
+  <build_depend>non_existing_dep</build_depend>
+</package>
+
+

--- a/run_build_impl.sh
+++ b/run_build_impl.sh
@@ -74,11 +74,13 @@ if [ -z "$PACKAGES" ]; then
 		# Read the package name from the xml.
 	    package="$(echo 'cat //name/text()' | xmllint --shell ${package_xml} | grep -Ev "/|-")"
 		pkg_path=${package_xml%package.xml}
-		if [ ! -f "${pkg_path}/CATKIN_IGNORE" ]; then
-		    PACKAGES="${PACKAGES} $package"
-			echo "Added package $package."
-		else
+		if [ -f "${pkg_path}/CATKIN_IGNORE" ]; then
 			echo "Skipping package $package since the package contains CATKIN_IGNORE."
+		elif [ -f "${pkg_path}/CI_IGNORE" ]; then
+			echo "Skipping package $package since the package contains CI_IGNORE."
+		else
+			PACKAGES="${PACKAGES} $package"
+			echo "Added package $package."
 	    fi
 	done
 	echo "Found $PACKAGES by autodiscovery."


### PR DESCRIPTION
but not from catkin in general, as CATKIN_IGNORE does