### PR TITLE
Added "-e" to all shell scripts for better error catching.

### DIFF
--- a/run_build.sh
+++ b/run_build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 ## This script does nothing but update the local repo and then forward everything
 ## to the actual build script which by this time is updated from the remote.
 CWD=$(pwd)

--- a/run_build_catkin_or_rosbuild
+++ b/run_build_catkin_or_rosbuild
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd $WORKSPACE/src

--- a/run_build_impl.sh
+++ b/run_build_impl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 export PATH=/usr/local/bin/:$PATH
 
 source /opt/ros/indigo/setup.sh


### PR DESCRIPTION
(CI should rather fail than give green light without having done what was expected)

For example the test (http://129.132.38.183:8080/job/continuous_integration/168/consoleText) for https://github.com/ethz-asl/continuous_integration/pull/60 silently failed, because the error parser would not catch bash's complain:
```/var/lib/jenkins/jobs/continuous_integration/workspace/src/continuous_integration/run_build_impl.sh: line 197: RUN_AUTOMATIC_EVALUATION: command not found```