### PR TITLE
Support local rosinstall files.

### DIFF
--- a/ci_unit_tests/test/Test.py
+++ b/ci_unit_tests/test/Test.py
@@ -57,9 +57,11 @@ class TestCi(unittest.TestCase):
         import workspace.src.test_package.testTools as testTools
         for revision in revisions :
             rep = 'continuous_integration';
-            dependencies = 'git@github.com:ethz-asl/%s.git;%s' % (rep, revision);
-            
-            sha1 = testTools.rev_parse('.', ('' if re.match('^[0-9a-f]+$',revision)  else 'origin/') + revision);
+            if type(revision) in (tuple, list) :
+                dependencies, sha1 = revision
+            else:
+                dependencies = 'git@github.com:ethz-asl/%s.git;%s' % (rep, revision);
+                sha1 = testTools.rev_parse('.', ('' if re.match('^[0-9a-f]+$',revision)  else 'origin/') + revision);
             
             env[testTools.CheckEnvVariable] = "self.checkDependency('../../src/dependencies/%s', '%s')" % (rep, sha1);
             self._testRunBuild(['--dependencies=%s' % dependencies,  '--packages=test_package', '-s', '-n'])
@@ -75,6 +77,8 @@ class TestCi(unittest.TestCase):
     def test_simpleGitDescribeLikeRevision(self):
         self._test_dependencies(['notExistingTagOrBranch-32-g0295dad964']);
 
+    def test_localRosInstallFile(self):
+        self._test_dependencies([['./test_package/local.rosinstall', '0295dad96441fd2b9227caa5dbd2edfc5d438718']]);
 
 if __name__ == '__main__':
     unittest.main()

--- a/ci_unit_tests/test/workspace/src/.gitignore
+++ b/ci_unit_tests/test/workspace/src/.gitignore
@@ -1,0 +1,3 @@
+/.rosinstall
+/.rosinstall.bak
+/CMakeLists.txt

--- a/ci_unit_tests/test/workspace/src/test_package/TestPackage.py
+++ b/ci_unit_tests/test/workspace/src/test_package/TestPackage.py
@@ -6,10 +6,16 @@ import subprocess
 
 import testTools
 
+def sha1Equal(a, b):
+    a = a.strip();
+    b = b.strip();
+    return len(a) >= 5 and len(a) >= 5 and b.startswith(a) or a.startswith(b)
+
 class TestPackage(unittest.TestCase):
     def checkDependency(self, folder, sha1):
         print "Checking dependency revision: folder=%s, sha1=%s." %(folder, sha1)
-        self.assertEqual(testTools.rev_parse(folder, 'HEAD'), sha1, "Dependency folder %s is not checked out with revision %s" % (folder, sha1))
+        actualSha1 = testTools.rev_parse(folder, 'HEAD');
+        self.assertTrue(sha1Equal(actualSha1, sha1), "Dependency folder %s is not checked out with revision %s. Instead it is %s" % (folder, sha1, actualSha1))
 
     def test_external_check(self):
         toEval = os.environ[testTools.CheckEnvVariable];

--- a/ci_unit_tests/test/workspace/src/test_package/local.rosinstall
+++ b/ci_unit_tests/test/workspace/src/test_package/local.rosinstall
@@ -1,0 +1,1 @@
+- git: {local-name: continuous_integration, uri: 'git@github.com:ethz-asl/continuous_integration.git', version: 'test_dependencies/0'}


### PR DESCRIPTION
Dependencies matching "./*.rosinstall" are now merged into the workspace. 
WARNING: currently it is not possible to mix git URIs with rosinstall files.