### PR TITLE
Introduced --no_merge_devel flag

### DIFF
--- a/catkin_make_repo
+++ b/catkin_make_repo
@@ -16,6 +16,10 @@ else
   echo "Will only build $PACKAGES and skip tests."
 fi
 
+if $MERGE_DEVEL; then
+  catkin config --merge-devel # Necessary for catkin_tools >= 0.4.
+fi
+
 catkin build -w $WORKSPACE --verbose --no-status $PACKAGES --make-args $MAKE_ARGS --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-DALWAYS_ASSERT -DCMAKE_C_FLAGS=-DALWAYS_ASSERT
 ret_code=$?
 if [ $ret_code != 0 ]; then

--- a/run_build_impl.sh
+++ b/run_build_impl.sh
@@ -10,6 +10,7 @@ DEPENDENCIES=""
 COMPILER="gcc"
 RUN_TESTS=true
 RUN_CPPCHECK=true
+MERGE_DEVEL=true
 CHECKOUT_CATKIN_SIMPLE=true
 
 # DEPS must be below src/ !
@@ -34,6 +35,9 @@ case $i in
   -t|--no_tests)
   RUN_TESTS=false
   ;;
+  -M|--no_merge_devel)
+  MERGE_DEVEL=false
+  ;;
   -n|--no_cppcheck)
   RUN_CPPCHECK=false
   ;;
@@ -45,6 +49,7 @@ case $i in
     echo "  [{-p|--packages}=packages]"
     echo "  [{--compiler}=gcc/clang]"
     echo "  [{-t|--no_tests} skip gtest execution]"
+    echo "  [{-M|--no_merge_devel} don't activate catkin merge-devel mode]"
     echo "  [{-c|--no_cppcheck} skip cppcheck execution]"
     echo "  [{-s|--no_catkinsimple} skip checking out catkin simple]"
   ;;


### PR DESCRIPTION
If not set `catkin config --merge-devel` is called before `catkin build`
@eggerk thanks for the tip.