### PR TITLE
Do not ignore CMake warnings and errors!

### DIFF
--- a/logparser_rules
+++ b/logparser_rules
@@ -1,5 +1,3 @@
-# Ignore cmake warnings:
-ok /^CMake/
 # Some classes end with Error e.g. MarginalizationError, where the scoping :: helps to disambiguate.
 ok /[Ee]rror::/
 # Failures to init Gui
@@ -19,7 +17,10 @@ error /error: /
 error /Check failure stack trace:/
 
 # CMake errors:
-error /CMake Error/
+error /^CMake\u0020Error/
+
+# CMake warnings:
+warning /^CMake\u0020Warning/
 
 # Tests:
 #start /FAILURES:/


### PR DESCRIPTION
@ethz-asl/lab-ci-admins , does anybody know a good reason to ignore CMake warnings and or **errors** in the log parsing rule, as it was before?

If not I'm going to merge this.

