### PR TITLE
rename environment variable

### DIFF
--- a/modules/common_definitions.sh
+++ b/modules/common_definitions.sh
@@ -10,10 +10,10 @@ fi
 if [ -z "$_COMMON_LOADED_" ]; then
   _COMMON_LOADED_=true
 
-  ROS_VERSION=$(source $CI_MODULES/get_latest_ros_version.sh)
+  ROS_VERSION_NAME=$(source $CI_MODULES/get_latest_ros_version.sh)
   
   # Source current ROS
-  source /opt/ros/$ROS_VERSION/setup.sh
+  source /opt/ros/$ROS_VERSION_NAME/setup.sh
   
   # DEPS must be below src/ !
   DEPS=src/dependencies

--- a/rosmake_repo
+++ b/rosmake_repo
@@ -28,7 +28,7 @@ if ! command -v rosws > /dev/null ; then
   sudo apt-get install -y python-rosinstall
 fi
 
-rosws init $ROS_WS /opt/ros/$ROS_VERSION
+rosws init $ROS_WS /opt/ros/$ROS_VERSION_NAME
 
 for package in $(find ./* -type d)
 do

--- a/run_build_impl.sh
+++ b/run_build_impl.sh
@@ -175,7 +175,7 @@ echo "-----------------------------"
 
 echo "Initialize workspace:"
 echo "-----------------------------"
-source /opt/ros/$ROS_VERSION/setup.sh
+source /opt/ros/$ROS_VERSION_NAME/setup.sh
 
 cd $WORKSPACE/
 mkdir -vp $WORKSPACE/src


### PR DESCRIPTION
In newer installs of ROS Kinetic, ROS_VERSION is set by ros itself (ROS_VERSION=1). To avoid conflicts, I renamed it.